### PR TITLE
Seems like the usage of pack.Recycle() needs an input

### DIFF
--- a/s3_output.go
+++ b/s3_output.go
@@ -98,7 +98,7 @@ func (so *S3Output) Run(or OutputRunner, h PluginHelper) (err error) {
 				err = nil
 				continue
 			}
-			pack.Recycle()
+			pack.Recycle(nil)
 		case <- tickerChan:
 			or.LogMessage(fmt.Sprintf("Ticker fired, uploading payload."))
 			err := so.Upload(buffer, or, false)


### PR DESCRIPTION
I get compile errors without the `nil` input

Per this doc. 
https://godoc.org/github.com/mozilla-services/heka/pipeline#PipelinePack.Recycle
